### PR TITLE
Vue modifications

### DIFF
--- a/vueapp/assets/js/myvue.js
+++ b/vueapp/assets/js/myvue.js
@@ -20,16 +20,14 @@ new Vue({
             return `${this.siteURL}/wp-json/wp/v2/posts?per_page=3`;
         }
     },
-        let posts = this.$http.get( jsforwp_vars.site_url + '/wp-json/wp/v2/posts?per_page=3').then(response => {
-
-            // get body data
-            // console.log( response.body );
-            this.posts = response.body;
-
-        }, response => {
-            // error callback
-        });
     created() {
         console.log( this.siteURL );
+        axios.get( this.restEndpoint )
+          .then( response => this.posts = response.data )
+          .catch( error => {
+              alert('There was an error in your request');
+              console.error( error.response.data.message );
+            }
+        );
     }
 });

--- a/vueapp/assets/js/myvue.js
+++ b/vueapp/assets/js/myvue.js
@@ -1,4 +1,4 @@
-let vm = new Vue({
+new Vue({
     el: '#vueapp',
     data: {
         isSingle: false,

--- a/vueapp/assets/js/myvue.js
+++ b/vueapp/assets/js/myvue.js
@@ -6,15 +6,14 @@ let vm = new Vue({
         post: '',
     },
     methods: {
-        showPost: function( post ) {
+        showPost( post ) {
             this.post = post;
             this.isSingle = true;
         },
-        showPosts: function () {
+        showPosts() {
             this.isSingle = false;
         },
     },
-    created: function () {
         console.log( jsforwp_vars.site_url );
         let posts = this.$http.get( jsforwp_vars.site_url + '/wp-json/wp/v2/posts?per_page=3').then(response => {
 
@@ -25,5 +24,6 @@ let vm = new Vue({
         }, response => {
             // error callback
         });
+    created() {
     }
 });

--- a/vueapp/assets/js/myvue.js
+++ b/vueapp/assets/js/myvue.js
@@ -2,8 +2,8 @@ new Vue({
     el: '#vueapp',
     data: {
         isSingle: false,
-        posts: '',
-        post: '',
+        posts: [],
+        post: {},
     },
     methods: {
         showPost( post ) {

--- a/vueapp/assets/js/myvue.js
+++ b/vueapp/assets/js/myvue.js
@@ -4,6 +4,7 @@ new Vue({
         isSingle: false,
         posts: [],
         post: {},
+        siteURL: jsforwp_vars.site_url
     },
     methods: {
         showPost( post ) {
@@ -12,9 +13,13 @@ new Vue({
         },
         showPosts() {
             this.isSingle = false;
-        },
+        }
     },
-        console.log( jsforwp_vars.site_url );
+    computed: {
+        restEndpoint() {
+            return `${this.siteURL}/wp-json/wp/v2/posts?per_page=3`;
+        }
+    },
         let posts = this.$http.get( jsforwp_vars.site_url + '/wp-json/wp/v2/posts?per_page=3').then(response => {
 
             // get body data
@@ -25,5 +30,6 @@ new Vue({
             // error callback
         });
     created() {
+        console.log( this.siteURL );
     }
 });

--- a/vueapp/custom.php
+++ b/vueapp/custom.php
@@ -19,7 +19,7 @@
 
           <div id="vueapp" class="entry-content" v-cloak>
 
-            <ul id="post-list" v-if="!isSingle">
+            <ul v-if="!isSingle">
                 <li v-for="post in posts" :key="post.id">
                     <a v-bind:href="'#/'+post.slug" v-on:click="showPost( post )">
                         {{ post.title.rendered }}
@@ -27,8 +27,8 @@
                 </li>
             </ul>
 
-            <div id="post-content" v-else>
                 <p><a href="#/" v-on:click="showPosts"><< Back to Posts</a></p>
+            <div v-else>
                 <h2 v-text="post.title.rendered"></h2>
                 <div v-html="post.content.rendered"></div>
             </div>

--- a/vueapp/custom.php
+++ b/vueapp/custom.php
@@ -21,14 +21,14 @@
 
             <ul v-if="!isSingle">
                 <li v-for="post in posts" :key="post.id">
-                    <a v-bind:href="'#/'+post.slug" v-on:click="showPost( post )">
+                    <a :href="'#/'+post.slug" @click="showPost(post)">
                         {{ post.title.rendered }}
                     </a>
                 </li>
             </ul>
 
-                <p><a href="#/" v-on:click="showPosts"><< Back to Posts</a></p>
             <div v-else>
+                <p><a href="#/" @click="showPosts"><< Back to Posts</a></p>
                 <h2 v-text="post.title.rendered"></h2>
                 <div v-html="post.content.rendered"></div>
             </div>

--- a/vueapp/custom.php
+++ b/vueapp/custom.php
@@ -42,6 +42,7 @@
 
   </div>
 
-  <?php get_sidebar(); ?>
-
-<?php get_footer(); ?>
+  <?php 
+  get_sidebar(); 
+  
+get_footer();

--- a/vueapp/custom.php
+++ b/vueapp/custom.php
@@ -32,6 +32,7 @@
                 <h2 v-text="post.title.rendered"></h2>
                 <div v-html="post.content.rendered"></div>
             </div>
+
           </div>
 
         </article>

--- a/vueapp/functions.php
+++ b/vueapp/functions.php
@@ -21,11 +21,9 @@ add_action( 'wp_enqueue_scripts', 'wphierarchy_enqueue_styles' );
 function wphierarchy_enqueue_scripts() {
 
   if ( is_page_template( 'custom.php' ) ) {
-
-    wp_enqueue_script( 'vue-js', 'https://unpkg.com/vue@2.4.1', [], null, true );
-    wp_enqueue_script( 'vue-resource', 'https://cdn.jsdelivr.net/npm/vue-resource@1.3.4', [], null, true );
-    wp_enqueue_script( 'my-vue-js', get_stylesheet_directory_uri() . '/assets/js/myvue.js', [ 'vue-js','vue-resource'
-     ], time(), true );
+    wp_enqueue_script( 'axios', 'https://unpkg.com/axios/dist/axios.min.js', [], null, true );
+    wp_enqueue_script( 'vue-js', 'https://unpkg.com/vue@2.4.1', [ 'axios' ], null, true );
+    wp_enqueue_script( 'my-vue-js', get_stylesheet_directory_uri() . '/assets/js/myvue.js', [ 'vue-js' ], time(), true );
 
     wp_localize_script('my-vue-js', 'jsforwp_vars', array(
             'site_url' => esc_url( site_url() )


### PR DESCRIPTION
This PR addresses some Vue code updates, namely dropping support for the retired vue-resource http library in favor of axios.

We've also cleaned up some of the markup, remove unnecessary code where appropriate and using vue shorthand properties for directives.

Updated function syntax to newer ES6 format.

Also being more declarative with the wp_localize_script variables by passing them into the Vue instance.